### PR TITLE
feat(frontend/global-popup): add global popup component

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -110,7 +110,66 @@ stores/
 ├── gameStore.ts      # 遊戲進度與狀態
 ├── boothStore.ts     # 攤位 session
 ├── staffStore.ts     # 工作人員狀態
+├── popupStore.ts     # 全域 popup 佇列（不 persist）
 └── index.ts          # Barrel export
+```
+
+### Global Popup（全域蓋板通知）
+
+任何元件皆可透過 `usePopupStore` 觸發全域 popup，掛載於 Root layout（`app/layout.tsx`），所有頁面（玩家、工作人員）共用。
+
+**元件位置：** `components/ui/GlobalPopup.tsx` / **Store 位置：** `stores/popupStore.ts`
+
+**PopupData 欄位：**
+
+| 欄位 | 必填 | 說明 |
+|------|------|------|
+| `title` | ✅ | 標題文字（font-serif, text-2xl） |
+| `description` | ❌ | 說明文字 |
+| `image` | ❌ | 圖片 URL，以 aspect-[4/3] 顯示 |
+| `cta` | ❌ | `{ name, link }` — 行動按鈕，`/` 開頭內部導航，否則開新分頁 |
+| `doneText` | ❌ | 關閉按鈕文字，預設「關閉」 |
+
+**Store API：**
+- `showPopup(popup)` — 加入佇列，id 自動產生
+- `dismissPopup(id)` — 關閉指定 popup
+- `clearAll()` — 清空所有 popup
+
+**行為：**
+- 佇列機制 — `popups` 為陣列，UI 只顯示 `popups[0]`，dismiss 後自動顯示下一個
+- backdrop 點擊不會自動關閉，使用者必須點按鈕操作
+- 不使用 persist，重整後不保留
+
+**範例 1 — 完整通知（圖片 + CTA + 自訂按鈕文字）：**
+
+```typescript
+import { usePopupStore } from "@/stores";
+
+const showPopup = usePopupStore((s) => s.showPopup);
+
+showPopup({
+  title: "獲得新優惠券！",
+  description: "恭喜你獲得 50 元折價券",
+  image: "/assets/coupon-reward.png",
+  cta: { name: "查看優惠券", link: "/coupon" },
+  doneText: "知道了",
+});
+```
+
+**範例 2 — 純文字提示（無圖片、無 CTA）：**
+
+```typescript
+showPopup({
+  title: "交朋友已滿！",
+  description: "你已經收集到所有朋友了，快去領取獎勵吧。",
+});
+```
+
+**範例 3 — 連續觸發多個（佇列）：**
+
+```typescript
+showPopup({ title: "第一個通知", description: "這是佇列中的第一個" });
+showPopup({ title: "第二個通知", description: "關掉第一個後會看到我" });
 ```
 
 ---

--- a/frontend/app/(player)/popup-test/page.tsx
+++ b/frontend/app/(player)/popup-test/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { usePopupStore } from "@/stores";
+
+export default function TestPage() {
+  const showPopup = usePopupStore((s) => s.showPopup);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6">
+      <h1 className="font-serif text-2xl font-bold">Popup 測試頁</h1>
+
+      <button
+        onClick={() =>
+          showPopup({
+            title: "獲得新優惠券！",
+            description: "恭喜你獲得 50 元折價券",
+            image: "/assets/coupon-reward.png",
+            cta: { name: "查看優惠券", link: "/coupon" },
+            doneText: "知道了",
+          })
+        }
+        className="rounded-full bg-[var(--accent-gold)] px-6 py-3 font-bold text-white active:scale-95"
+      >
+        測試：有圖 + CTA
+      </button>
+
+      <button
+        onClick={() =>
+          showPopup({
+            title: "交朋友已滿！",
+            description: "你已經收集到所有朋友了，快去領取獎勵吧。",
+          })
+        }
+        className="rounded-full bg-[var(--bg-header)] px-6 py-3 font-bold text-[var(--text-light)] active:scale-95"
+      >
+        測試：純文字
+      </button>
+
+      <button
+        onClick={() => {
+          showPopup({ title: "第一個通知", description: "這是佇列中的第一個" });
+          showPopup({ title: "第二個通知", description: "關掉第一個後會看到我" });
+        }}
+        className="rounded-full bg-[var(--bg-header)] px-6 py-3 font-bold text-[var(--text-light)] active:scale-95"
+      >
+        測試：佇列（連續兩個）
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Noto_Sans_TC, Noto_Serif_TC } from "next/font/google";
 import QueryProvider from "@/components/providers/QueryProvider";
+import GlobalPopup from "@/components/ui/GlobalPopup";
 import "@/app/globals.css";
 
 const notoSans = Noto_Sans_TC({
@@ -30,7 +31,10 @@ export default function RootLayout({
       <body
         className={`${notoSans.variable} ${notoSerif.variable} bg-[var(--bg-primary)] text-[var(--text-primary)] antialiased`}
       >
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          {children}
+          <GlobalPopup />
+        </QueryProvider>
       </body>
     </html>
   );

--- a/frontend/components/ui/GlobalPopup.tsx
+++ b/frontend/components/ui/GlobalPopup.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { usePopupStore } from "@/stores";
+
+export default function GlobalPopup() {
+  const router = useRouter();
+  const popups = usePopupStore((s) => s.popups);
+  const dismissPopup = usePopupStore((s) => s.dismissPopup);
+
+  const current = popups[0] ?? null;
+
+  const handleCta = () => {
+    if (!current?.cta) return;
+    const { link } = current.cta;
+    if (link.startsWith("/")) {
+      router.push(link);
+    } else {
+      window.open(link, "_blank");
+    }
+    dismissPopup(current.id);
+  };
+
+  const handleDone = () => {
+    if (!current) return;
+    dismissPopup(current.id);
+  };
+
+  return (
+    <AnimatePresence>
+      {current && (
+        <motion.div
+          key={current.id}
+          className="fixed inset-0 z-50 flex items-center justify-center px-6"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          {/* Backdrop */}
+          <div className="absolute inset-0 bg-black/50" />
+
+          {/* Card */}
+          <motion.div
+            className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-[var(--bg-primary)] shadow-2xl"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+          >
+            {/* Image */}
+            {current.image && (
+              <div className="relative aspect-[4/3] w-full">
+                <Image
+                  src={current.image}
+                  alt={current.title}
+                  fill
+                  className="object-contain"
+                />
+              </div>
+            )}
+
+            {/* Content */}
+            <div className="space-y-3 p-6">
+              <h2 className="font-serif text-2xl font-bold text-[var(--text-primary)]">
+                {current.title}
+              </h2>
+              {current.description && (
+                <p className="text-sm text-[var(--text-secondary)]">
+                  {current.description}
+                </p>
+              )}
+            </div>
+
+            {/* Buttons */}
+            <div className="space-y-3 px-6 pb-6">
+              {current.cta && (
+                <button
+                  onClick={handleCta}
+                  className="w-full rounded-full bg-[var(--accent-gold)] py-3 text-base font-bold tracking-widest text-white shadow-md transition-transform active:scale-95"
+                >
+                  {current.cta.name}
+                </button>
+              )}
+              <button
+                onClick={handleDone}
+                className="w-full rounded-full bg-[var(--bg-header)] py-3 text-base font-bold tracking-widest text-[var(--text-light)] shadow-md transition-transform active:scale-95"
+              >
+                {current.doneText ?? "關閉"}
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/stores/index.ts
+++ b/frontend/stores/index.ts
@@ -1,3 +1,4 @@
 export { useUserStore } from "./userStore";
 export { useBoothStore } from "./boothStore";
 export { useStaffStore } from "./staffStore";
+export { usePopupStore } from "./popupStore";

--- a/frontend/stores/popupStore.ts
+++ b/frontend/stores/popupStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+export interface PopupData {
+  id: string;
+  title: string;
+  description?: string;
+  image?: string;
+  cta?: {
+    name: string;
+    link: string;
+  };
+  doneText?: string;
+}
+
+interface PopupState {
+  popups: PopupData[];
+  showPopup: (popup: Omit<PopupData, "id">) => void;
+  dismissPopup: (id: string) => void;
+  clearAll: () => void;
+}
+
+export const usePopupStore = create<PopupState>((set) => ({
+  popups: [],
+  showPopup: (popup) =>
+    set((state) => ({
+      popups: [
+        ...state.popups,
+        { ...popup, id: crypto.randomUUID() },
+      ],
+    })),
+  dismissPopup: (id) =>
+    set((state) => ({
+      popups: state.popups.filter((p) => p.id !== id),
+    })),
+  clearAll: () => set({ popups: [] }),
+}));


### PR DESCRIPTION
可以從 `/popup-test` 進行測試效果。

`showPopup()` 的使用說明，請參見 `@AGENT.md`。

<img width="455" height="877" alt="image" src="https://github.com/user-attachments/assets/efd23fcf-adc6-485e-9ffe-266263684548" />

popup card 分為 ：
- 有圖+CTA
- 純文字
- 連續 N 個

<img width="426" height="875" alt="image" src="https://github.com/user-attachments/assets/acffb58a-d4b9-4775-be6e-6f3e124fe8fe" />
<img width="414" height="312" alt="image" src="https://github.com/user-attachments/assets/deea6aea-a9a8-4fba-96c4-5b0992275a45" />


related to #23 